### PR TITLE
Restructure base class

### DIFF
--- a/finvoker/invoker.py
+++ b/finvoker/invoker.py
@@ -24,8 +24,7 @@ class InvokerBase(object):
         self._arg_pattern = re.compile(f'^{label}\\.([^.]+)$.([^.]+)$')
 
     def run(self):
-        self.refresh_services()
-        self.loop.run_forever()
+        pass
 
     def refresh_services(self):
         services = list(filter(lambda s: any(self._type_pattern.match(k)

--- a/finvoker/invoker.py
+++ b/finvoker/invoker.py
@@ -17,10 +17,18 @@ class InvokerBase(object):
         self.refresh_interval = refresh_interval
         self.last_refresh = 0
         self._services = {}
-        self._invoker_label = label
-        self._invoker_name = name
+        self._label = label
+        self._name = name
         self._type_pattern = re.compile(f'^{label}\\.([^.]+)$')
         self._arg_pattern = re.compile(f'^{label}\\.([^.]+)$.([^.]+)$')
+
+    @property
+    def label(self):
+        return self._label
+
+    @property
+    def name(self):
+        return self._name
 
     def run(self):
         pass

--- a/finvoker/invoker.py
+++ b/finvoker/invoker.py
@@ -12,12 +12,13 @@ class InvokerBase(object):
 
     invokers = []
 
-    def __init__(self, refresh_interval=5, label='finvoker'):
+    def __init__(self, refresh_interval=5, label='finvoker', name=None):
         self.client = docker.from_env()
         self.refresh_interval = refresh_interval
         self.last_refresh = 0
         self._services = {}
         self._invoker_label = label
+        self._invoker_name = name
         self._type_pattern = re.compile(f'^{label}\\.([^.]+)$')
         self._arg_pattern = re.compile(f'^{label}\\.([^.]+)$.([^.]+)$')
 

--- a/finvoker/invoker.py
+++ b/finvoker/invoker.py
@@ -1,4 +1,3 @@
-import asyncio
 import datetime
 import logging
 import re
@@ -15,7 +14,6 @@ class InvokerBase(object):
 
     def __init__(self, refresh_interval=5, label='finvoker'):
         self.client = docker.from_env()
-        self.loop = asyncio.new_event_loop()
         self.refresh_interval = refresh_interval
         self.last_refresh = ''
         self._services = {}
@@ -53,7 +51,6 @@ class InvokerBase(object):
             self._notify_for_service(service, 3)
 
         self.last_refresh = datetime.datetime.utcnow().isoformat()
-        self.loop.call_later(self.refresh_interval, self.refresh_services)
 
     def _notify_for_service(self, service, function_idx):
         labels = service.attrs.get('Spec', {}).get('Labels', {})

--- a/finvoker/invoker.py
+++ b/finvoker/invoker.py
@@ -9,7 +9,7 @@ import docker
 log = logging.getLogger(__name__)
 
 
-class InvocationManager(object):
+class InvokerBase(object):
 
     invokers = []
 

--- a/finvoker/invoker.py
+++ b/finvoker/invoker.py
@@ -19,7 +19,7 @@ class InvokerBase(object):
         self._services = {}
         self._label = label
         self._name = name
-        self._register_pattern = re.compile(f'^{label}\\.{name}$')
+        self._register_label = f'{label}.{name}'
         self._argument_pattern = re.compile(f'^{label}\\.{name}\\.([^.]+)$')
 
     @property
@@ -34,9 +34,7 @@ class InvokerBase(object):
         pass
 
     def refresh_services(self):
-        services = list(filter(lambda s: any(self._register_pattern.match(k)
-                                             for k
-                                             in s.attrs.get('Spec', {}).get('Labels', {}).keys()),
+        services = list(filter(lambda s: self._register_label in s.attrs.get('Spec', {}).get('Labels', {}),
                                self.client.services.list()))
 
         new_services = []

--- a/finvoker/invoker.py
+++ b/finvoker/invoker.py
@@ -73,8 +73,3 @@ class InvokerBase(object):
                 in [(self._argument_pattern.match(k), v) for k, v in labels.items()] if m}
         log.debug(f'{service.attrs["Spec"]["Name"]} arguments: {args}')
         return args
-
-
-def register(matchstr, add_f, update_f=None, remove_f=None, flags=0):
-    InvocationManager.invokers.append((re.compile(matchstr, flags), add_f, update_f, remove_f))
-    log.info(f'Registered {add_f.__name__} for {matchstr}')

--- a/finvoker/invoker.py
+++ b/finvoker/invoker.py
@@ -12,7 +12,7 @@ class InvokerBase(object):
 
     invokers = []
 
-    def __init__(self, refresh_interval=5, label='finvoker', name=None):
+    def __init__(self, label='finvoker', name=None, refresh_interval=5):
         self.client = docker.from_env()
         self.refresh_interval = refresh_interval
         self.last_refresh = 0

--- a/finvoker/invoker.py
+++ b/finvoker/invoker.py
@@ -40,9 +40,9 @@ class InvokerBase(object):
         services = list(filter(lambda s: self._register_label in s.attrs.get('Spec', {}).get('Labels', {}),
                                self.client.services.list()))
 
-        new_services = []
-        updated_services = []
-        removed_services = []
+        add_services = []
+        update_services = []
+        remove_services = []
 
         # Scan for new and updated services
         for service in services:
@@ -50,22 +50,22 @@ class InvokerBase(object):
 
             if not existing_service:
                 # register a new service
-                log.debug(f'New service: {service.attrs["Spec"]["Name"]} ({service.id})')
-                new_services.append(service)
+                log.debug(f'Add service: {service.attrs["Spec"]["Name"]} ({service.id})')
+                added_services.append(service)
                 self._services[service.id] = service
             elif service.attrs['UpdatedAt'] > existing_service.attrs['UpdatedAt']:
                 # maybe update an already registered service
-                log.debug(f'Updated service: {service.attrs["Spec"]["Name"]} ({service.id})')
-                updated_services.append(service)
+                log.debug(f'Update service: {service.attrs["Spec"]["Name"]} ({service.id})')
+                update_services.append(service)
 
         # Scan for removed services
         for service_id in set(self._services.keys()) - set([s.id for s in services]):
             service = self._services.pop(service_id)
-            log.debug(f'Removed service: {service.attrs["Spec"]["Name"]} ({service.id})')
-            removed_services.append(service)
+            log.debug(f'Remove service: {service.attrs["Spec"]["Name"]} ({service.id})')
+            remove_services.append(service)
 
         self.last_refresh = time.time()
-        return new_services, updated_services, removed_services
+        return add_service, update_services, remove_services
 
     def arguments(self, service):
         labels = service.attrs.get('Spec', {}).get('Labels', {})

--- a/finvoker/invoker.py
+++ b/finvoker/invoker.py
@@ -19,8 +19,8 @@ class InvokerBase(object):
         self._services = {}
         self._label = label
         self._name = name
-        self._type_pattern = re.compile(f'^{label}\\.([^.]+)$')
-        self._arg_pattern = re.compile(f'^{label}\\.([^.]+)$.([^.]+)$')
+        self._register_pattern = re.compile(f'^{label}\\.{name}$')
+        self._argument_pattern = re.compile(f'^{label}\\.{name}\\.([^.]+)$')
 
     @property
     def label(self):
@@ -34,7 +34,7 @@ class InvokerBase(object):
         pass
 
     def refresh_services(self):
-        services = list(filter(lambda s: any(self._type_pattern.match(k)
+        services = list(filter(lambda s: any(self._register_pattern.match(k)
                                              for k
                                              in s.attrs.get('Spec', {}).get('Labels', {}).keys()),
                                self.client.services.list()))

--- a/finvoker/invoker.py
+++ b/finvoker/invoker.py
@@ -1,6 +1,6 @@
-import datetime
 import logging
 import re
+import time
 
 import docker
 
@@ -15,7 +15,7 @@ class InvokerBase(object):
     def __init__(self, refresh_interval=5, label='finvoker'):
         self.client = docker.from_env()
         self.refresh_interval = refresh_interval
-        self.last_refresh = ''
+        self.last_refresh = 0
         self._services = {}
         self._invoker_label = label
         self._type_pattern = re.compile(f'^{label}\\.([^.]+)$')
@@ -50,7 +50,7 @@ class InvokerBase(object):
             log.debug(f'Removed service: {service.attrs["Spec"]["Name"]} ({service.id})')
             self._notify_for_service(service, 3)
 
-        self.last_refresh = datetime.datetime.utcnow().isoformat()
+        self.last_refresh = time.time()
 
     def _notify_for_service(self, service, function_idx):
         labels = service.attrs.get('Spec', {}).get('Labels', {})

--- a/finvoker/invoker.py
+++ b/finvoker/invoker.py
@@ -33,7 +33,10 @@ class InvokerBase(object):
     def run(self):
         pass
 
-    def refresh_services(self):
+    def refresh_services(self, force=False):
+        if not force and time.time() - self.last_refresh < self.refresh_interval:
+            return [], [], []
+
         services = list(filter(lambda s: self._register_label in s.attrs.get('Spec', {}).get('Labels', {}),
                                self.client.services.list()))
 


### PR DESCRIPTION
Rename the InvocationManager class to InvokerBase. It is being
restructured to be the base class of individual invocation handlers.
The manager + multiple registered invokers design is a bad idea because
it effectively forces a macro-service design, and complicates loop
management.