### PR TITLE
Add a primitive implementation of a Kafka based invoker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.1-alpine
+FROM ucalgary/python-librdkafka:3.6.1-0.9.5
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/finvoker/invoker.py
+++ b/finvoker/invoker.py
@@ -51,7 +51,7 @@ class InvokerBase(object):
             if not existing_service:
                 # register a new service
                 log.debug(f'Add service: {service.attrs["Spec"]["Name"]} ({service.id})')
-                added_services.append(service)
+                add_services.append(service)
                 self._services[service.id] = service
             elif service.attrs['UpdatedAt'] > existing_service.attrs['UpdatedAt']:
                 # maybe update an already registered service
@@ -65,7 +65,7 @@ class InvokerBase(object):
             remove_services.append(service)
 
         self.last_refresh = time.time()
-        return add_service, update_services, remove_services
+        return add_services, update_services, remove_services
 
     def arguments(self, service):
         labels = service.attrs.get('Spec', {}).get('Labels', {})

--- a/finvoker/kafka.py
+++ b/finvoker/kafka.py
@@ -1,0 +1,72 @@
+import atexit
+import collections
+import logging
+
+import requests
+try:
+    import ujson as json
+except:
+    import json
+from confluent_kafka import Consumer
+
+from .invoker import InvokerBase
+
+
+log = logging.getLogger(__name__)
+
+
+class KafkaInvoker(InvokerBase):
+
+    def __init__(self, label='finvoker', name='kafka', refresh_interval=5,
+                 kafka=('kafka:9092',)):
+        super().__init__(label=label, name=name, refresh_interval=refresh_interval)
+        self.config = {
+            'bootstrap.servers': ','.join(kafka),
+            'group.id': self._register_label,
+            'default.topic.config': {
+                'auto.offset.reset': 'largest',
+                'auto.commit.interval.ms': 5000
+            }
+        }
+
+    def run(self):
+        consumer = Consumer(self.config)
+        callbacks = collections.defaultdict(list)
+
+        def close():
+            log.info('Closing consumer')
+            consumer.close()
+        atexit.register(close)
+
+        while True:
+            add, update, remove = self.refresh_services()
+            if add or update or remove:
+                existing_topics = set(callbacks.keys())
+
+                for s in add:
+                    callbacks[self.arguments(s).get('topic')].append(s)
+                for s in update:
+                    pass
+                for s in remove:
+                    callbacks[self.arguments(s).get('topic')].remove(s)
+
+                interested_topics = set(callbacks.keys())
+
+                if existing_topics.symmetric_difference(interested_topics):
+                    log.debug(f'Subscribing to {interested_topics}')
+                    consumer.subscribe(list(interested_topics))
+
+            message = consumer.poll(timeout=self.refresh_interval)
+            if not message:
+                log.debug('Empty message received')
+            elif not message.error():
+                topic, key, value = message.topic(), \
+                                    message.key().decode('utf-8'), \
+                                    json.loads(message.value())
+                for service in callbacks[topic]:
+                    requests.post(f'http://gateway:8080/function/{service.attrs["Spec"]["Name"]}', data=key)
+
+
+def main():
+    invoker = KafkaInvoker()
+    invoker.run()

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
     install_requires=install_requires,
     dependency_links=dependency_links,
     entry_points="""
+    kafka-invoker=finvoker.kafka:main
     """,
     zip_safe=True
 )

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
     install_requires=install_requires,
     dependency_links=dependency_links,
     entry_points="""
+    [console_scripts]
     kafka-invoker=finvoker.kafka:main
     """,
     zip_safe=True

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,8 @@ from setuptools import setup
 
 
 install_requires = [
-    'docker==2.2.1'
+    'docker==2.2.1',
+    'confluent-kafka==0.9.4'
 ]
 
 


### PR DESCRIPTION
kafka-invoker subscribes to Kafka topics and invokes functions when messages are received on the topics. Function services should have a label named finvoker.kafka to enable this invoker, and specify a topic via a finvoker.kafka.topic label.