### PR TITLE
Set configurations via environment variables

### DIFF
--- a/finvoker/invoker.py
+++ b/finvoker/invoker.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import re
 import time
 
@@ -14,11 +15,11 @@ class InvokerBase(object):
 
     def __init__(self, label='finvoker', name=None, refresh_interval=5):
         self.client = docker.from_env()
-        self.refresh_interval = refresh_interval
+        self.refresh_interval = int(os.getenv('INVOKER_REFRESH_INTERVAL', refresh_interval))
         self.last_refresh = 0
         self._services = {}
-        self._label = label
-        self._name = name
+        self._label = os.getenv('INVOKER_LABEL', label)
+        self._name = os.getenv('INVOKER_NAME', name)
         self._register_label = f'{label}.{name}'
         self._argument_pattern = re.compile(f'^{label}\\.{name}\\.([^.]+)$')
 

--- a/finvoker/kafka.py
+++ b/finvoker/kafka.py
@@ -1,6 +1,7 @@
 import atexit
 import collections
 import logging
+import os
 
 import requests
 try:
@@ -21,8 +22,8 @@ class KafkaInvoker(InvokerBase):
                  kafka='kafka:9092'):
         super().__init__(label=label, name=name, refresh_interval=refresh_interval)
         self.config = {
-            'bootstrap.servers': kafka,
-            'group.id': self._register_label,
+            'bootstrap.servers': os.getenv('KAFKA_BOOTSTRAP_SERVERS', kafka),
+            'group.id': os.getenv('KAFKA_CONSUMER_GROUP', self._register_label),
             'default.topic.config': {
                 'auto.offset.reset': 'largest',
                 'auto.commit.interval.ms': 5000

--- a/finvoker/kafka.py
+++ b/finvoker/kafka.py
@@ -18,10 +18,10 @@ log = logging.getLogger(__name__)
 class KafkaInvoker(InvokerBase):
 
     def __init__(self, label='finvoker', name='kafka', refresh_interval=5,
-                 kafka=('kafka:9092',)):
+                 kafka='kafka:9092'):
         super().__init__(label=label, name=name, refresh_interval=refresh_interval)
         self.config = {
-            'bootstrap.servers': ','.join(kafka),
+            'bootstrap.servers': kafka,
             'group.id': self._register_label,
             'default.topic.config': {
                 'auto.offset.reset': 'largest',


### PR DESCRIPTION
Add support for setting configurations via environment variables.

| Config            | ENV                      |
|-------------------|--------------------------|
| refresh_interval  | INVOKER_REFRESH_INTERVAL |
| label             | INVOKER_LABEL            |
| name              | INVOKER_NAME             |
| bootstrap.servers | KAFKA_BOOTSTRAP_SERVERS  |
| group.id          | KAFKA_CONSUMER_GROUP     |