### PR TITLE
Add options for function request body

### DIFF
--- a/ftrigger/kafka.py
+++ b/ftrigger/kafka.py
@@ -69,7 +69,7 @@ class KafkaTrigger(TriggerBase):
                     requests.post(f'http://gateway:8080/function/{service.attrs["Spec"]["Name"]}', data=data)
 
     def function_data(self, service, topic, key, value):
-        data_opt = self.arguments(s).get('data', 'key')
+        data_opt = self.arguments(service).get('data', 'key')
 
         if data_opt == 'key-value':
             return json.dumps({'key': key, 'value': value})

--- a/ftrigger/kafka.py
+++ b/ftrigger/kafka.py
@@ -65,7 +65,16 @@ class KafkaTrigger(TriggerBase):
                                     message.key().decode('utf-8'), \
                                     json.loads(message.value())
                 for service in callbacks[topic]:
-                    requests.post(f'http://gateway:8080/function/{service.attrs["Spec"]["Name"]}', data=key)
+                    data = self.function_data(service, topic, key, value)
+                    requests.post(f'http://gateway:8080/function/{service.attrs["Spec"]["Name"]}', data=data)
+
+    def function_data(self, service, topic, key, value):
+        data_opt = self.arguments(s).get('data', 'key')
+
+        if data_opt == 'key-value':
+            return json.dumps({'key': key, 'value': value})
+        else:
+            return key
 
 
 def main():


### PR DESCRIPTION
Add an option named data (labeled as ftrigger.kafka.data) to specify
the data that is sent with a function request. If key-value, a JSON
object with the Kafka message key and value is sent. Otherwise, the
message key is sent as a plain string.

Closes #9.