### PR TITLE
Read functions from gateway

### DIFF
--- a/ftrigger/kafka.py
+++ b/ftrigger/kafka.py
@@ -73,7 +73,7 @@ class KafkaTrigger(TriggerBase):
                     pass
                 for function in callbacks[topic]:
                     data = self.function_data(function, topic, key, value)
-                    self.gateway.post(self._gateway_base + '/function/{function["name"]}', data=data)
+                    self.gateway.post(self._gateway_base + f'/function/{function["name"]}', data=data)
 
     def function_data(self, function, topic, key, value):
         data_opt = self.arguments(function).get('data', 'key')

--- a/ftrigger/kafka.py
+++ b/ftrigger/kafka.py
@@ -40,16 +40,16 @@ class KafkaTrigger(TriggerBase):
         atexit.register(close)
 
         while True:
-            add, update, remove = self.refresh_services()
+            add, update, remove = self.refresh_functions()
             if add or update or remove:
                 existing_topics = set(callbacks.keys())
 
-                for s in add:
-                    callbacks[self.arguments(s).get('topic')].append(s)
-                for s in update:
+                for f in add:
+                    callbacks[self.arguments(f).get('topic')].append(s)
+                for f in update:
                     pass
-                for s in remove:
-                    callbacks[self.arguments(s).get('topic')].remove(s)
+                for f in remove:
+                    callbacks[self.arguments(f).get('topic')].remove(s)
 
                 interested_topics = set(callbacks.keys())
 
@@ -72,11 +72,12 @@ class KafkaTrigger(TriggerBase):
                     value = json.loads(value)
                 except:
                     pass
-                for service in callbacks[topic]:
-                    data = self.function_data(service, topic, key, value)
-                    requests.post(f'http://gateway:8080/function/{service.attrs["Spec"]["Name"]}', data=data)
+                for function in callbacks[topic]:
+                    data = self.function_data(function, topic, key, value)
+                    requests.post(f'http://gateway:8080/function/{function["name"]}', data=data)
 
-    def function_data(self, service, topic, key, value):
+    def function_data(self, function, topic, key, value):
+        service = function['service']
         data_opt = self.arguments(service).get('data', 'key')
 
         if data_opt == 'key-value':

--- a/ftrigger/kafka.py
+++ b/ftrigger/kafka.py
@@ -3,7 +3,6 @@ import collections
 import logging
 import os
 
-import requests
 try:
     import ujson as json
 except:
@@ -74,7 +73,7 @@ class KafkaTrigger(TriggerBase):
                     pass
                 for function in callbacks[topic]:
                     data = self.function_data(function, topic, key, value)
-                    requests.post(f'http://gateway:8080/function/{function["name"]}', data=data)
+                    self.gateway.post(self._gateway_base + '/function/{function["name"]}', data=data)
 
     def function_data(self, function, topic, key, value):
         service = function['service']

--- a/ftrigger/kafka.py
+++ b/ftrigger/kafka.py
@@ -44,11 +44,11 @@ class KafkaTrigger(TriggerBase):
                 existing_topics = set(callbacks.keys())
 
                 for f in add:
-                    callbacks[self.arguments(f).get('topic')].append(s)
+                    callbacks[self.arguments(f).get('topic')].append(f)
                 for f in update:
                     pass
                 for f in remove:
-                    callbacks[self.arguments(f).get('topic')].remove(s)
+                    callbacks[self.arguments(f).get('topic')].remove(f)
 
                 interested_topics = set(callbacks.keys())
 

--- a/ftrigger/kafka.py
+++ b/ftrigger/kafka.py
@@ -76,8 +76,7 @@ class KafkaTrigger(TriggerBase):
                     self.gateway.post(self._gateway_base + '/function/{function["name"]}', data=data)
 
     def function_data(self, function, topic, key, value):
-        service = function['service']
-        data_opt = self.arguments(service).get('data', 'key')
+        data_opt = self.arguments(function).get('data', 'key')
 
         if data_opt == 'key-value':
             return json.dumps({'key': key, 'value': value})

--- a/ftrigger/trigger.py
+++ b/ftrigger/trigger.py
@@ -108,7 +108,8 @@ class TriggerBase(object):
         self.last_refresh = time.time()
         return add_functions, update_functions, remove_functions
 
-    def arguments(self, service):
+    def arguments(self, function):
+        service = function['service']
         labels = service.attrs.get('Spec', {}).get('Labels', {})
         if self._register_label not in labels:
             return None

--- a/ftrigger/trigger.py
+++ b/ftrigger/trigger.py
@@ -4,6 +4,7 @@ import re
 import time
 
 import docker
+import requests
 
 
 log = logging.getLogger(__name__)
@@ -21,6 +22,7 @@ class TriggerBase(object):
         self._register_label = f'{label}.{name}'
         self._argument_pattern = re.compile(f'^{label}\\.{name}\\.([^.]+)$')
         self._gateway_base = gateway.rstrip('/')
+        self.gateway = requests.Session()
 
     @property
     def label(self):

--- a/ftrigger/trigger.py
+++ b/ftrigger/trigger.py
@@ -103,6 +103,7 @@ class TriggerBase(object):
             log.debug(f'Remove function: {function["name"]} ({funcion["service"].id})')
             remove_functions.append(function)
 
+        self.last_refresh = time.time()
         return add_functions, update_functions, remove_functions
 
     def arguments(self, service):

--- a/ftrigger/trigger.py
+++ b/ftrigger/trigger.py
@@ -100,6 +100,8 @@ class TriggerBase(object):
         # Scan for removed functions
         for function_name in set(self._functions.keys()) - set([f['name'] for f in functions]):
             function = self._functions.pop(function_name)
+            log.debug(f'Remove function: {function["name"]} ({funcion["service"].id})')
+            remove_functions.append(function)
 
         return add_functions, update_functions, remove_functions
 

--- a/ftrigger/trigger.py
+++ b/ftrigger/trigger.py
@@ -17,6 +17,7 @@ class TriggerBase(object):
         self.refresh_interval = int(os.getenv('TRIGGER_REFRESH_INTERVAL', refresh_interval))
         self.last_refresh = 0
         self._services = {}
+        self._functions = {}
         self._label = os.getenv('TRIGGER_LABEL', label)
         self._name = os.getenv('TRIGGER_NAME', name)
         self._register_label = f'{label}.{name}'

--- a/ftrigger/trigger.py
+++ b/ftrigger/trigger.py
@@ -81,6 +81,8 @@ class TriggerBase(object):
         functions = self.gateway.get(self._gateway_base + '/system/functions').json()
         for function in functions:
             function['service'] = self.client.services.get(function['name'])
+        functions = list(filter(lambda f: self._register_label in f['service'].attrs.get('Spec', {}).get('Labels', {}),
+                                functions))
 
         # Scan for new and updated functions
         for function in functions:

--- a/ftrigger/trigger.py
+++ b/ftrigger/trigger.py
@@ -78,6 +78,21 @@ class TriggerBase(object):
         update_functions = []
         remove_functions = []
 
+        functions = self.gateway.get(self._gateway_base + '/system/functions').json()
+
+        # Scan for new and updated functions
+        for function in functions:
+            existing_function = self._functions.get(function['name'])
+
+            if not existing_function:
+                pass
+            else:
+                pass
+
+        # Scan for removed functions
+        for function_name in set(self._functions.keys()) - set([f['name'] for f in functions]):
+            function = self._functions.pop(function_name)
+
         return add_functions, update_functions, remove_functions
 
     def arguments(self, service):

--- a/ftrigger/trigger.py
+++ b/ftrigger/trigger.py
@@ -87,9 +87,15 @@ class TriggerBase(object):
             existing_function = self._functions.get(function['name'])
 
             if not existing_function:
-                pass
-            else:
-                pass
+                # register a new function
+                log.debug(f'Add function: {function["name"]} ({funcion["service"].id})')
+                add_functions.append(function)
+                self._functions[function['name']] = function
+            elif function['service'].attrs['UpdatedAt'] > existing_function['service'].attrs['UpdatedAt']:
+                # maybe update an already registered function
+                log.debug(f'Update function: {function["name"]} ({funcion["service"].id})')
+                update_functions.append(function)
+                self._functions[function['name']] = function
 
         # Scan for removed functions
         for function_name in set(self._functions.keys()) - set([f['name'] for f in functions]):

--- a/ftrigger/trigger.py
+++ b/ftrigger/trigger.py
@@ -79,6 +79,8 @@ class TriggerBase(object):
         remove_functions = []
 
         functions = self.gateway.get(self._gateway_base + '/system/functions').json()
+        for function in functions:
+            function['service'] = self.client.services.get(function['name'])
 
         # Scan for new and updated functions
         for function in functions:

--- a/ftrigger/trigger.py
+++ b/ftrigger/trigger.py
@@ -66,6 +66,16 @@ class TriggerBase(object):
         self.last_refresh = time.time()
         return add_services, update_services, remove_services
 
+    def refresh_functions(self, force=False):
+        if not force and time.time() - self.last_refresh < self.refresh_interval:
+            return [], [], []
+
+        add_functions = []
+        update_functions = []
+        remove_functions = []
+
+        return add_functions, update_functions, remove_functions
+
     def arguments(self, service):
         labels = service.attrs.get('Spec', {}).get('Labels', {})
         if self._register_label not in labels:

--- a/ftrigger/trigger.py
+++ b/ftrigger/trigger.py
@@ -88,19 +88,19 @@ class TriggerBase(object):
 
             if not existing_function:
                 # register a new function
-                log.debug(f'Add function: {function["name"]} ({funcion["service"].id})')
+                log.debug(f'Add function: {function["name"]} ({function["service"].id})')
                 add_functions.append(function)
                 self._functions[function['name']] = function
             elif function['service'].attrs['UpdatedAt'] > existing_function['service'].attrs['UpdatedAt']:
                 # maybe update an already registered function
-                log.debug(f'Update function: {function["name"]} ({funcion["service"].id})')
+                log.debug(f'Update function: {function["name"]} ({function["service"].id})')
                 update_functions.append(function)
                 self._functions[function['name']] = function
 
         # Scan for removed functions
         for function_name in set(self._functions.keys()) - set([f['name'] for f in functions]):
             function = self._functions.pop(function_name)
-            log.debug(f'Remove function: {function["name"]} ({funcion["service"].id})')
+            log.debug(f'Remove function: {function["name"]} ({function["service"].id})')
             remove_functions.append(function)
 
         self.last_refresh = time.time()

--- a/ftrigger/trigger.py
+++ b/ftrigger/trigger.py
@@ -11,7 +11,7 @@ log = logging.getLogger(__name__)
 
 class TriggerBase(object):
 
-    def __init__(self, label='ftrigger', name=None, refresh_interval=5):
+    def __init__(self, label='ftrigger', name=None, refresh_interval=5, gateway='http://gateway:8080'):
         self.client = docker.from_env()
         self.refresh_interval = int(os.getenv('TRIGGER_REFRESH_INTERVAL', refresh_interval))
         self.last_refresh = 0
@@ -20,6 +20,7 @@ class TriggerBase(object):
         self._name = os.getenv('TRIGGER_NAME', name)
         self._register_label = f'{label}.{name}'
         self._argument_pattern = re.compile(f'^{label}\\.{name}\\.([^.]+)$')
+        self._gateway_base = gateway.rstrip('/')
 
     @property
     def label(self):

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,9 @@ from setuptools import setup
 
 
 install_requires = [
+    'confluent-kafka',
     'docker',
-    'confluent-kafka'
+    'requests',
 ]
 
 


### PR DESCRIPTION
Modify TriggerBase to read functions from the FaaS API Gateway and evaluate their services for triggering, instead of all services from the Docker engine. This aligns triggers exactly with the functions registered with a gateway, instead of Docker services which may or may not be known to a gateway.

Closes #14 