### PR TITLE
Remove services and reduce TriggerBase to a library

### DIFF
--- a/ftrigger/kafka.py
+++ b/ftrigger/kafka.py
@@ -39,7 +39,7 @@ class KafkaTrigger(object):
         atexit.register(close)
 
         while True:
-            add, update, remove = functions.refresh_functions()
+            add, update, remove = functions.refresh()
             if add or update or remove:
                 existing_topics = set(callbacks.keys())
 

--- a/ftrigger/kafka.py
+++ b/ftrigger/kafka.py
@@ -9,7 +9,7 @@ except:
     import json
 from confluent_kafka import Consumer
 
-from .trigger import TriggerBase
+from .trigger import Functions
 
 
 log = logging.getLogger(__name__)
@@ -19,7 +19,7 @@ class KafkaTrigger(object):
 
     def __init__(self, label='ftrigger', name='kafka', refresh_interval=5,
                  kafka='kafka:9092'):
-        self.functions = TriggerBase(name='kafka')
+        self.functions = Functions(name='kafka')
         self.config = {
             'bootstrap.servers': os.getenv('KAFKA_BOOTSTRAP_SERVERS', kafka),
             'group.id': os.getenv('KAFKA_CONSUMER_GROUP', self._register_label),

--- a/ftrigger/kafka.py
+++ b/ftrigger/kafka.py
@@ -32,6 +32,7 @@ class KafkaTrigger(object):
     def run(self):
         consumer = Consumer(self.config)
         callbacks = collections.defaultdict(list)
+        functions = self.functions
 
         def close():
             log.info('Closing consumer')
@@ -76,7 +77,7 @@ class KafkaTrigger(object):
                     functions.gateway.post(functions._gateway_base + f'/function/{function["name"]}', data=data)
 
     def function_data(self, function, topic, key, value):
-        data_opt = functions.arguments(function).get('data', 'key')
+        data_opt = self.functions.arguments(function).get('data', 'key')
 
         if data_opt == 'key-value':
             return json.dumps({'key': key, 'value': value})

--- a/ftrigger/kafka.py
+++ b/ftrigger/kafka.py
@@ -73,7 +73,7 @@ class KafkaTrigger(object):
                 except:
                     pass
                 for function in callbacks[topic]:
-                    data = functions.function_data(function, topic, key, value)
+                    data = self.function_data(function, topic, key, value)
                     functions.gateway.post(functions._gateway_base + f'/function/{function["name"]}', data=data)
 
     def function_data(self, function, topic, key, value):

--- a/ftrigger/kafka.py
+++ b/ftrigger/kafka.py
@@ -22,7 +22,7 @@ class KafkaTrigger(object):
         self.functions = Functions(name='kafka')
         self.config = {
             'bootstrap.servers': os.getenv('KAFKA_BOOTSTRAP_SERVERS', kafka),
-            'group.id': os.getenv('KAFKA_CONSUMER_GROUP', self._register_label),
+            'group.id': os.getenv('KAFKA_CONSUMER_GROUP', self.functions._register_label),
             'default.topic.config': {
                 'auto.offset.reset': 'largest',
                 'auto.commit.interval.ms': 5000

--- a/ftrigger/trigger.py
+++ b/ftrigger/trigger.py
@@ -32,7 +32,7 @@ class Functions(object):
     def name(self):
         return self._name
 
-    def refresh_functions(self, force=False):
+    def refresh(self, force=False):
         if not force and time.time() - self.last_refresh < self.refresh_interval:
             return [], [], []
 

--- a/ftrigger/trigger.py
+++ b/ftrigger/trigger.py
@@ -10,7 +10,7 @@ import requests
 log = logging.getLogger(__name__)
 
 
-class TriggerBase(object):
+class Functions(object):
 
     def __init__(self, label='ftrigger', name=None, refresh_interval=5, gateway='http://gateway:8080'):
         self.client = docker.from_env()

--- a/ftrigger/trigger.py
+++ b/ftrigger/trigger.py
@@ -16,7 +16,6 @@ class TriggerBase(object):
         self.client = docker.from_env()
         self.refresh_interval = int(os.getenv('TRIGGER_REFRESH_INTERVAL', refresh_interval))
         self.last_refresh = 0
-        self._services = {}
         self._functions = {}
         self._label = os.getenv('TRIGGER_LABEL', label)
         self._name = os.getenv('TRIGGER_NAME', name)
@@ -35,40 +34,6 @@ class TriggerBase(object):
 
     def run(self):
         pass
-
-    def refresh_services(self, force=False):
-        if not force and time.time() - self.last_refresh < self.refresh_interval:
-            return [], [], []
-
-        services = list(filter(lambda s: self._register_label in s.attrs.get('Spec', {}).get('Labels', {}),
-                               self.client.services.list()))
-
-        add_services = []
-        update_services = []
-        remove_services = []
-
-        # Scan for new and updated services
-        for service in services:
-            existing_service = self._services.get(service.id)
-
-            if not existing_service:
-                # register a new service
-                log.debug(f'Add service: {service.attrs["Spec"]["Name"]} ({service.id})')
-                add_services.append(service)
-                self._services[service.id] = service
-            elif service.attrs['UpdatedAt'] > existing_service.attrs['UpdatedAt']:
-                # maybe update an already registered service
-                log.debug(f'Update service: {service.attrs["Spec"]["Name"]} ({service.id})')
-                update_services.append(service)
-
-        # Scan for removed services
-        for service_id in set(self._services.keys()) - set([s.id for s in services]):
-            service = self._services.pop(service_id)
-            log.debug(f'Remove service: {service.attrs["Spec"]["Name"]} ({service.id})')
-            remove_services.append(service)
-
-        self.last_refresh = time.time()
-        return add_services, update_services, remove_services
 
     def refresh_functions(self, force=False):
         if not force and time.time() - self.last_refresh < self.refresh_interval:

--- a/ftrigger/trigger.py
+++ b/ftrigger/trigger.py
@@ -32,9 +32,6 @@ class TriggerBase(object):
     def name(self):
         return self._name
 
-    def run(self):
-        pass
-
     def refresh_functions(self, force=False):
         if not force and time.time() - self.last_refresh < self.refresh_interval:
             return [], [], []


### PR DESCRIPTION
Remove leftover references to services from the switch to functions. Also, reduce TriggerBase to use as a library object instead of a framework superclass for trigger implementations.

Closes #22