### PR TITLE
Retry gateway calls

### DIFF
--- a/ftrigger/trigger.py
+++ b/ftrigger/trigger.py
@@ -5,6 +5,7 @@ import time
 
 import docker
 import requests
+from requests.adapters import HTTPAdapter
 
 
 log = logging.getLogger(__name__)
@@ -23,6 +24,7 @@ class Functions(object):
         self._argument_pattern = re.compile(f'^{label}\\.{name}\\.([^.]+)$')
         self._gateway_base = gateway.rstrip('/')
         self.gateway = requests.Session()
+        self.gateway.mount(self._gateway_base, HTTPAdapter(max_retries=50))
 
     @property
     def label(self):

--- a/ftrigger/trigger.py
+++ b/ftrigger/trigger.py
@@ -24,7 +24,7 @@ class Functions(object):
         self._argument_pattern = re.compile(f'^{label}\\.{name}\\.([^.]+)$')
         self._gateway_base = gateway.rstrip('/')
         self.gateway = requests.Session()
-        self.gateway.mount(self._gateway_base, HTTPAdapter(max_retries=50))
+        self.gateway.mount(self._gateway_base, HTTPAdapter(max_retries=int(os.getenv('GATEWAY_RETRY', 50))))
 
     @property
     def label(self):


### PR DESCRIPTION
Retry HTTP calls to the FaaS API gateway. This is currently a simply retry of up to 50 times. POST requests may require configuring a custom Retry object.

Closes #15 