### PR TITLE
Use function labels from gateway

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.2'
 
 services:
   gateway:
-    image: functions/gateway:0.6.6-beta
+    image: functions/gateway:0.6.15
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,8 +20,6 @@ services:
   ftrigger-kafka:
     image: ucalgary/ftrigger:master
     command: kafka-trigger
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
     networks:
       - functions
       - streaming

--- a/ftrigger/trigger.py
+++ b/ftrigger/trigger.py
@@ -3,7 +3,6 @@ import os
 import re
 import time
 
-import docker
 import requests
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
@@ -15,7 +14,6 @@ log = logging.getLogger(__name__)
 class Functions(object):
 
     def __init__(self, label='ftrigger', name=None, refresh_interval=5, gateway='http://gateway:8080'):
-        self.client = docker.from_env()
         self.refresh_interval = int(os.getenv('TRIGGER_REFRESH_INTERVAL', refresh_interval))
         self.last_refresh = 0
         self._functions = {}

--- a/ftrigger/trigger.py
+++ b/ftrigger/trigger.py
@@ -63,7 +63,8 @@ class Functions(object):
                 log.debug(f'Add function: {function["name"]} ({function["service"].id})')
                 add_functions.append(function)
                 self._functions[function['name']] = function
-            elif function['service'].attrs['UpdatedAt'] > existing_function['service'].attrs['UpdatedAt']:
+            elif False:
+            # elif function['service'].attrs['UpdatedAt'] > existing_function['service'].attrs['UpdatedAt']:
                 # maybe update an already registered function
                 log.debug(f'Update function: {function["name"]} ({function["service"].id})')
                 update_functions.append(function)

--- a/ftrigger/trigger.py
+++ b/ftrigger/trigger.py
@@ -49,6 +49,9 @@ class Functions(object):
         remove_functions = []
 
         functions = self.gateway.get(self._gateway_base + '/system/functions').json()
+        if self._stack_namespace:
+            functions = filter(lambda f: f.get('labels', {}).get('com.docker.stack.namespace') == self._stack_namespace,
+                               functions)
         functions = list(filter(lambda f: self._register_label in f.get('labels', {}), functions))
 
         # Scan for new and updated functions

--- a/ftrigger/trigger.py
+++ b/ftrigger/trigger.py
@@ -79,12 +79,11 @@ class Functions(object):
         return add_functions, update_functions, remove_functions
 
     def arguments(self, function):
-        service = function['service']
-        labels = service.attrs.get('Spec', {}).get('Labels', {})
+        labels = function.get('labels', {})
         if self._register_label not in labels:
             return None
 
         args = {m.group(1): v for m, v
                 in [(self._argument_pattern.match(k), v) for k, v in labels.items()] if m}
-        log.debug(f'{service.attrs["Spec"]["Name"]} arguments: {args}')
+        log.debug(f'{function["name"]} arguments: {args}')
         return args

--- a/ftrigger/trigger.py
+++ b/ftrigger/trigger.py
@@ -52,8 +52,7 @@ class Functions(object):
         functions = self.gateway.get(self._gateway_base + '/system/functions').json()
         for function in functions:
             function['service'] = self.client.services.get(function['name'])
-        functions = list(filter(lambda f: self._register_label in f['service'].attrs.get('Spec', {}).get('Labels', {}),
-                                functions))
+        functions = list(filter(lambda f: self._register_label in f.get('labels', {}), functions))
 
         # Scan for new and updated functions
         for function in functions:

--- a/ftrigger/trigger.py
+++ b/ftrigger/trigger.py
@@ -50,8 +50,6 @@ class Functions(object):
         remove_functions = []
 
         functions = self.gateway.get(self._gateway_base + '/system/functions').json()
-        for function in functions:
-            function['service'] = self.client.services.get(function['name'])
         functions = list(filter(lambda f: self._register_label in f.get('labels', {}), functions))
 
         # Scan for new and updated functions

--- a/ftrigger/trigger.py
+++ b/ftrigger/trigger.py
@@ -17,6 +17,7 @@ class Functions(object):
         self.refresh_interval = int(os.getenv('TRIGGER_REFRESH_INTERVAL', refresh_interval))
         self.last_refresh = 0
         self._functions = {}
+        self._stack_namespace = os.getenv('STACK_NAMESPACE', None)
         self._label = os.getenv('TRIGGER_LABEL', label)
         self._name = os.getenv('TRIGGER_NAME', name)
         self._register_label = f'{label}.{name}'

--- a/ftrigger/trigger.py
+++ b/ftrigger/trigger.py
@@ -60,20 +60,20 @@ class Functions(object):
 
             if not existing_function:
                 # register a new function
-                log.debug(f'Add function: {function["name"]} ({function["service"].id})')
+                log.debug(f'Add function: {function["name"]}')
                 add_functions.append(function)
                 self._functions[function['name']] = function
             elif False:
             # elif function['service'].attrs['UpdatedAt'] > existing_function['service'].attrs['UpdatedAt']:
                 # maybe update an already registered function
-                log.debug(f'Update function: {function["name"]} ({function["service"].id})')
+                log.debug(f'Update function: {function["name"]}')
                 update_functions.append(function)
                 self._functions[function['name']] = function
 
         # Scan for removed functions
         for function_name in set(self._functions.keys()) - set([f['name'] for f in functions]):
             function = self._functions.pop(function_name)
-            log.debug(f'Remove function: {function["name"]} ({function["service"].id})')
+            log.debug(f'Remove function: {function["name"]}')
             remove_functions.append(function)
 
         self.last_refresh = time.time()

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@ from setuptools import setup
 
 install_requires = [
     'confluent-kafka',
-    'docker',
     'requests',
 ]
 


### PR DESCRIPTION
OpenFaaS Gateway 0.6.9 and later directly provide the labels from services underlying functions. This removes the need to contact a Docker Swarm manager node to get service labels.

Modify the `Functions` class to use the label information from the gateway directly instead of contacting Docker. As a side effect, service label updates are temporarily disabled since the clause for it uses the service update timestamp. This will be handled later.