### PR TITLE
Set backoff delay between retries to gateway

### DIFF
--- a/ftrigger/trigger.py
+++ b/ftrigger/trigger.py
@@ -29,6 +29,7 @@ class Functions(object):
             connect=int(os.getenv('GATEWAY_RETRY', 10)),
             read=10,
             redirect=10,
+            backoff_factor=0.1,
             method_whitelist=frozenset(['HEAD', 'GET', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'TRACE'])
         )))
 


### PR DESCRIPTION
Set backoff_factor to 0.1 to delay retries on connection failures to
the gateway. The default is 0, which does not perform backoff.