### PR TITLE
Add filter option to Kafka trigger

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,12 @@ COPY setup.py /usr/src/app
 COPY ftrigger /usr/src/app/ftrigger
 ARG SETUP_COMMAND=install
 RUN apk add --no-cache --virtual .build-deps \
+        autoconf \
+        automake \
         gcc \
         git \
+        libtool \
+        make \
         musl-dev && \
     python setup.py ${SETUP_COMMAND} && \
     apk del .build-deps

--- a/ftrigger/kafka.py
+++ b/ftrigger/kafka.py
@@ -7,6 +7,7 @@ try:
     import ujson as json
 except:
     import json
+import pyjq
 from confluent_kafka import Consumer
 
 from .trigger import Functions
@@ -73,6 +74,12 @@ class KafkaTrigger(object):
                 except:
                     pass
                 for function in callbacks[topic]:
+                    jq_filter = functions.arguments(function).get('filter')
+                    try:
+                        if jq_filter and not pyjq.first(jq_filter, value):
+                            continue
+                    except:
+                        log.error(f'Could not filter message value with {jq_filter}')
                     data = self.function_data(function, topic, key, value)
                     functions.gateway.post(functions._gateway_base + f'/function/{function["name"]}', data=data)
 

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ from setuptools import setup
 
 install_requires = [
     'confluent-kafka',
+    'pyjq',
     'requests',
 ]
 


### PR DESCRIPTION
For the Kafka based trigger, accept filters written as jq to be evaluated against message values.

If the filter evaluates to False, the associated function will not be called.
Otherwise, if the filter evaluates to True or fails to evaluate, the function will be called.